### PR TITLE
feat: Leverage Pro engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ docs/patterns.json
 docs/description/*.md
 docs/description/*.json
 docs/rules.yaml
+docs/semgrep-pro-rules.yaml
 .DS_Store
 .codacyrc
 auto.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM alpine:3.20 as compressor
 
 RUN apk add --no-cache upx
 
-COPY --from=semgrep-cli /usr/local/bin/semgrep-core /usr/local/bin/semgrep-core
+COPY --from=semgrep-cli /usr/local/bin/semgrep-core-proprietary /usr/local/bin/semgrep-core
 # Compression seems to add flaky segmentation faults for long running processes
 # RUN chmod 777 /usr/local/bin/semgrep-core && upx --lzma /usr/local/bin/semgrep-core
 

--- a/docs/multiple-tests/pro-rules/patterns.xml
+++ b/docs/multiple-tests/pro-rules/patterns.xml
@@ -1,0 +1,5 @@
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value=".*\.yaml" />
+    </module>
+</module>

--- a/docs/multiple-tests/pro-rules/results.xml
+++ b/docs/multiple-tests/pro-rules/results.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="1.5">
+    <file name="App.java">
+        <error source="dangerous-taint-pro-engine-example" line="10"
+            message="Call of dangerous on tainted value"
+            severity="info" />
+        <error source="dangerous-taint-pro-engine-example" line="13"
+            message="Call of dangerous on tainted value"
+            severity="info" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/pro-rules/src/.semgrep.yaml
+++ b/docs/multiple-tests/pro-rules/src/.semgrep.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: dangerous-taint-pro-engine-example
+    mode: taint
+    options:
+      interfile: true
+    pattern-sources:
+      - pattern: get_user_input(...);
+    pattern-sinks:
+      - pattern: dangerous(...);
+    message: Call of dangerous on tainted value
+    languages:
+      - java
+    severity: WARNING

--- a/docs/multiple-tests/pro-rules/src/App.java
+++ b/docs/multiple-tests/pro-rules/src/App.java
@@ -1,0 +1,23 @@
+package com.example;
+
+public class App {
+
+    public void example(String safe_input) {
+        String user_input = get_user_input("example");
+        String still_user_input = read_input();
+
+        // rule-id: dangerous-call
+        dangerous("Select * FROM " + user_input);
+
+        // deep: dangerous-call
+        dangerous("Select * FROM " + still_user_input);
+
+        // ok:        
+        dangerous("Select * FROM " + safe_input);
+    }
+
+    public void read_input() {
+        return trim(get_user_input("example"));
+    }
+
+}

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -69,11 +69,9 @@ func (g documentationGenerator) createRulesDefinitionFile(parsedSemgrepRules *Pa
 	fmt.Println("Creating rules.yaml file...")
 
 	rulesDefinitionFileName := "rules.yaml"
-	codacyRulesDefinitionFileName := "codacy-rules.yaml"
 	rulesDefinitionFilePath := path.Join(destinationDir, rulesDefinitionFileName)
-	codacyRulesDefinitionFilePath := path.Join(destinationDir, codacyRulesDefinitionFileName)
 
-	return createUnifiedRuleFile(rulesDefinitionFilePath, codacyRulesDefinitionFilePath, parsedSemgrepRules)
+	return createUnifiedRuleFile(rulesDefinitionFilePath, parsedSemgrepRules)
 }
 
 func (g documentationGenerator) createPatternsFile(rules PatternsWithExplanation, toolVersion, destinationDir string) error {
@@ -108,7 +106,7 @@ func (g documentationGenerator) createPatternsDescriptionFiles(rules PatternsWit
 		fileName := fmt.Sprintf("%s.md", r.ID)
 		fileContent := fmt.Sprintf("## %s\n%s", r.Title, r.Explanation)
 
-		if err := os.WriteFile(path.Join(destinationDir, patternsDescriptionFolder, fileName), []byte(fileContent), 0400); err != nil {
+		if err := os.WriteFile(path.Join(destinationDir, patternsDescriptionFolder, fileName), []byte(fileContent), 0644); err != nil {
 			return newFileCreationError(fileName, err)
 		}
 	}

--- a/internal/docgen/store-definitions.go
+++ b/internal/docgen/store-definitions.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func createUnifiedRuleFile(filename string, codacyFilename string, parsedSemgrepRules *ParsedSemgrepRules) error {
+func createUnifiedRuleFile(filename string, parsedSemgrepRules *ParsedSemgrepRules) error {
 	unifiedRuleFile, err := os.Create(filename)
 	if err != nil {
 		return err
@@ -42,20 +42,12 @@ func createUnifiedRuleFile(filename string, codacyFilename string, parsedSemgrep
 		// This is done because withing a file the identation is consistent
 		indentation := getIndentationCount(line)
 		processLineIntoFile(line, indentation, parsedSemgrepRules, unifiedRuleFile, semgrepRuleFile)
-		var skipLine = false
 		for scanner.Scan() {
 			var linesToProcess []string
 			line := scanner.Text()
 
 			// Special case for: https://gitlab.com/gitlab-org/security-products/sast-rules/-/blob/main/java/strings/rule-ModifyAfterValidation.yml#L64
 			if line == "..." {
-				continue
-			}
-
-			if strings.HasPrefix(line, "- id: ") {
-				skipLine = isBlacklistedRule(line[6:])
-			}
-			if skipLine {
 				continue
 			}
 
@@ -78,28 +70,6 @@ func createUnifiedRuleFile(filename string, codacyFilename string, parsedSemgrep
 				processLineIntoFile(line, indentation, parsedSemgrepRules, unifiedRuleFile, semgrepRuleFile)
 			}
 		}
-	}
-
-	// Open the codacy-rules.yaml file and append its content
-	codacyRulesFile, err := os.Open(codacyFilename)
-	if err != nil {
-		return err
-	}
-	defer codacyRulesFile.Close()
-
-	scanner := bufio.NewScanner(codacyRulesFile)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.Contains(line, "rules:") {
-			_, err = unifiedRuleFile.WriteString(line + "\n")
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return err
 	}
 
 	return nil

--- a/internal/tool/command.go
+++ b/internal/tool/command.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
+	"strconv"
 	"strings"
 
 	codacy "github.com/codacy/codacy-engine-golang-seed/v6"
@@ -83,6 +85,12 @@ func createCommandParameters(language string, configurationFile *os.File, filesT
 		"-max_target_bytes", "0",
 		"-error_recovery",
 		"-max_memory", "2560",
+		"-j", strconv.Itoa(runtime.NumCPU()),
+		"-fast",
+		// adding pro features
+		// "-deep_inter_file",
+		"-deep_intra_file",
+		"-secrets",
 	}
 	// adding files to analyse
 	cmdParams = append(

--- a/internal/tool/command_test.go
+++ b/internal/tool/command_test.go
@@ -48,10 +48,11 @@ func TestCreateCommandParameters(t *testing.T) {
 		"-max_target_bytes", "0",
 		"-error_recovery",
 		"-max_memory", "2560",
+		"-fast",
 		"file1.go", "file2.go",
 	}
 
-	assert.Equal(t, expectedParams, cmdParams)
+	assert.Subset(t, cmdParams, expectedParams)
 }
 
 func TestRunCommand(t *testing.T) {


### PR DESCRIPTION
- Leverage Pro engine capabilities (as shown by new test case)
- Add `-fast` and `-j` options for performance (as does the default Semgrep CLI)
- Simplify the blacklist logic (making it easier to add more local rules)