### PR TITLE
Security: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/comment_issue.yml
+++ b/.github/workflows/comment_issue.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check GitHub Issue type
         if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
         id: github_issue_type
-        uses: actions/github-script@v2.0.0
+        uses: actions/github-script@6e5ee1dc1cb3740e5e5e76ad668e3f526edbfe45 # v2.0.0
         with:
           result-encoding: string
           script: |
@@ -33,7 +33,7 @@ jobs:
       - name: Check if GitHub Issue has JIRA_ISSUE_LABEL
         if: env.JIRA_CREATE_COMMENT_AUTO == 'true'
         id: github_issue_has_jira_issue_label
-        uses: actions/github-script@v2.0.0
+        uses: actions/github-script@6e5ee1dc1cb3740e5e5e76ad668e3f526edbfe45 # v2.0.0
         env:
           JIRA_ISSUE_LABEL: ${{ secrets.JIRA_ISSUE_LABEL }}
         with:
@@ -56,7 +56,7 @@ jobs:
       - name: Jira Login
         if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: login
-        uses: atlassian/gajira-login@v2.0.0
+        uses: atlassian/gajira-login@90a599561baaf8c05b080645ed73db7391c246ed # v2.0.0
         env:
           GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
           GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
@@ -67,7 +67,7 @@ jobs:
       - name: Extract Jira number
         if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: extract_jira_number
-        uses: actions/github-script@v2.0.0
+        uses: actions/github-script@6e5ee1dc1cb3740e5e5e76ad668e3f526edbfe45 # v2.0.0
         env:
           GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
           GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}
@@ -82,7 +82,7 @@ jobs:
       - name: Jira Add comment on issue
         if: env.JIRA_CREATE_COMMENT_AUTO == 'true' && env.GITHUB_ISSUE_TYPE == 'issue' && env.GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL == 'true'
         id: add_comment_jira_issue
-        uses: atlassian/gajira-comment@v2.0.2
+        uses: atlassian/gajira-comment@8ec356b5df49f1325653db7ee2da2b59a1d78203 # v2.0.2
         env:
           GITHUB_ISSUE_TYPE: ${{ steps.github_issue_type.outputs.result }}
           GITHUB_ISSUE_HAS_JIRA_ISSUE_LABEL: ${{ steps.github_issue_has_jira_issue_label.outputs.result }}

--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Jira Login
         if: env.JIRA_CREATE_ISSUE_AUTO == 'true'
         id: login
-        uses: atlassian/gajira-login@v2.0.0
+        uses: atlassian/gajira-login@90a599561baaf8c05b080645ed73db7391c246ed # v2.0.0
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -27,7 +27,7 @@ jobs:
       - name: Jira Create issue
         if: env.JIRA_CREATE_ISSUE_AUTO == 'true'
         id: create_jira_issue
-        uses: atlassian/gajira-create@v2.0.1
+        uses: atlassian/gajira-create@c0a9c69ac9d6aa063fed57201e55336ada860183 # v2.0.1
         with:
           project: ${{ secrets.JIRA_PROJECT }}
           issuetype: ${{ secrets.JIRA_ISSUE_TYPE }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Update GitHub issue
         if: env.JIRA_CREATE_ISSUE_AUTO == 'true'
-        uses: actions/github-script@v2.0.0
+        uses: actions/github-script@6e5ee1dc1cb3740e5e5e76ad668e3f526edbfe45 # v2.0.0
         env:
           JIRA_ISSUE_NUMBER: ${{ steps.create_jira_issue.outputs.issue }}
           GITHUB_ORIGINAL_TITLE: ${{ github.event.issue.title }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Add comment after sync
         if: env.JIRA_CREATE_ISSUE_AUTO == 'true'
-        uses: actions/github-script@v2.0.0
+        uses: actions/github-script@6e5ee1dc1cb3740e5e5e76ad668e3f526edbfe45 # v2.0.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/create_issue_on_label.yml
+++ b/.github/workflows/create_issue_on_label.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Jira Login
         if: github.event.label.name == env.JIRA_ISSUE_LABEL
         id: login
-        uses: atlassian/gajira-login@v2.0.0
+        uses: atlassian/gajira-login@90a599561baaf8c05b080645ed73db7391c246ed # v2.0.0
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -27,7 +27,7 @@ jobs:
       - name: Jira Create issue
         if: github.event.label.name == env.JIRA_ISSUE_LABEL
         id: create_jira_issue
-        uses: atlassian/gajira-create@v2.0.1
+        uses: atlassian/gajira-create@c0a9c69ac9d6aa063fed57201e55336ada860183 # v2.0.1
         with:
           project: ${{ secrets.JIRA_PROJECT }}
           issuetype: ${{ secrets.JIRA_ISSUE_TYPE }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Change Title
         if: github.event.label.name == env.JIRA_ISSUE_LABEL
-        uses: actions/github-script@v2.0.0
+        uses: actions/github-script@6e5ee1dc1cb3740e5e5e76ad668e3f526edbfe45 # v2.0.0
         env:
           JIRA_ISSUE_NUMBER: ${{ steps.create_jira_issue.outputs.issue }}
           GITHUB_ORIGINAL_TITLE: ${{ github.event.issue.title }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Add comment after sync
         if: github.event.label.name == env.JIRA_ISSUE_LABEL
-        uses: actions/github-script@v2.0.0
+        uses: actions/github-script@6e5ee1dc1cb3740e5e5e76ad668e3f526edbfe45 # v2.0.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/dependabot_auto_approve.yml
+++ b/.github/workflows/dependabot_auto_approve.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@8348ea7f5d949b08c7f125a44b569c9626b05db3 # v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@8348ea7f5d949b08c7f125a44b569c9626b05db3 # v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs


### PR DESCRIPTION
Pins all GitHub Actions from mutable tags/branches to immutable SHA hashes.

This prevents supply chain attacks like the TeamPCP/Trivy incident (March 2026), where attackers force-pushed tags to point at malicious commits.

Auto-generated by the Codacy security audit script.